### PR TITLE
fix bug #PSCSX-4596

### DIFF
--- a/themes/default-bootstrap/product-sort.tpl
+++ b/themes/default-bootstrap/product-sort.tpl
@@ -42,11 +42,16 @@
 	{/if}
 {/if}
 {if $page_name == 'best-sales' && (!isset($smarty.get.orderby) || empty($smarty.get.orderby))}{$orderby = ''}{$orderbydefault = ''}{/if}
+{assign 'sortOptionsArray' ['price', 'name', 'quantity', 'reference']}
 <form id="productsSortForm{if isset($paginationId)}_{$paginationId}{/if}" action="{$request|escape:'html':'UTF-8'}" class="productsSortForm">
 	<div class="select selector1">
 		<label for="selectProductSort{if isset($paginationId)}_{$paginationId}{/if}">{l s='Sort by'}</label>
 		<select id="selectProductSort{if isset($paginationId)}_{$paginationId}{/if}" class="selectProductSort form-control">
-			<option value="{if $page_name != 'best-sales'}{$orderbydefault|escape:'html':'UTF-8'}:{$orderwaydefault|escape:'html':'UTF-8'}{/if}"{if $orderby eq $orderbydefault} selected="selected"{/if}>--</option>
+			{if $orderbydefault|in_array:$sortOptionsArray}
+			<option disabled>{l s='Filter'}</option>
+			{else}
+			<option{if $page_name != 'best-sales'} value="{$orderbydefault|escape:'html':'UTF-8'}:{$orderwaydefault|escape:'html':'UTF-8'}"{/if}{if $orderby eq $orderbydefault} selected="selected"{/if}>{l s='--'}</option>
+			{/if}
 			{if !$PS_CATALOG_MODE}
 				<option value="price:asc"{if $orderby eq 'price' AND $orderway eq 'asc'} selected="selected"{/if}>{l s='Price: Lowest first'}</option>
 				<option value="price:desc"{if $orderby eq 'price' AND $orderway eq 'desc'} selected="selected"{/if}>{l s='Price: Highest first'}</option>


### PR DESCRIPTION
If you choose "Default order by PRODUCT PRICE, PRODUCT NAME, PRODUCT QUANTITY or PRODUCT REFERENCE" in back office settings, the selected attribute of #selectProductSort in front office duplicates that leads to errors in old browser.
here is the html code of such an error in product_sort.tpl in any category
<select id="selectProductSort" class="selectProductSort form-control">
<option value="price:asc" SELECTED="SELECTED">--</option>
<option value="price:asc" SELECTED="SELECTED">Price: Lowest first</option>
<option value="price:desc">Price: Highest first</option>
<option value="name:asc">Product Name: A to Z</option>
<option value="name:desc">Product Name: Z to A</option>
<option value="quantity:desc">In stock</option>
<option value="reference:asc">Reference: Lowest first</option>
<option value="reference:desc">Reference: Highest first</option>
</select>
that code will never pass w3c validation as well. If you choose other options in back office the problem dissappeare